### PR TITLE
Use the download_url function in display templates too 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
+* Use download_url for display templates also
+  [lentinj]
+
 * Fix the download view for widgets whose form has a custom getContent method.
   [davisagli]
 

--- a/plone/formwidget/namedfile/file_display.pt
+++ b/plone/formwidget/namedfile/file_display.pt
@@ -22,7 +22,7 @@
             tal:condition="python: exists and fieldname">
         <a tal:content="filename"
            tal:omit-tag="not:exists:context/absolute_url"
-           tal:attributes="href string:${context/absolute_url|nothing}/@@download/${fieldname}/${filename_encoded}">Filename</a>
+           tal:attributes="href view/download_url">Filename</a>
         <span class="discreet"> &mdash; <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span> KB</span>
     </span>
     <span tal:condition="not:exists" class="discreet" i18n:translate="no_file">

--- a/plone/formwidget/namedfile/image_display.pt
+++ b/plone/formwidget/namedfile/image_display.pt
@@ -23,7 +23,7 @@
                          height view/height;
                          alt view/alt"
              tal:condition="python:exists and fieldname"
-             tal:attributes="src string:${context/absolute_url}/@@download/${fieldname}/${filename_encoded};
+             tal:attributes="src view/download_url;
                              height view/height;
                              width view/width;
                              alt view/alt"


### PR DESCRIPTION
This seems slightly too obvious, I'm somewhat afraid.

However, it seems to help my case when the context is a Dict. (I'm also being naughty and overriding download_url, but that's another matter.)
