### PR TITLE
Ignore contentType sent by browsers for file uploads

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,11 +1,12 @@
 Changelog
 =========
 
-1.0.11 (unreleased)
--------------------
+1.1 (unreleased)
+----------------
 
-- Nothing changed yet.
-
+- Ignore contentType sent by browser for file uploads.
+  See https://github.com/plone/plone.formwidget.namedfile/issues/9
+  [lgraf]
 
 1.0.10 (2014-05-26)
 -------------------

--- a/plone/formwidget/namedfile/converter.py
+++ b/plone/formwidget/namedfile/converter.py
@@ -26,22 +26,17 @@ class NamedDataConverter(BaseDataConverter):
             return value
         elif isinstance(value, FileUpload):
             
-            headers = value.headers
             filename = safe_basename(value.filename)
             
             if filename is not None and not isinstance(filename, unicode):
                 # Work-around for
                 # https://bugs.launchpad.net/zope2/+bug/499696
                 filename = filename.decode('utf-8')
-            
-            contentType = 'application/octet-stream'
-            if headers:
-                contentType = headers.get('Content-Type', contentType)
-            
+
             value.seek(0)
             data = value.read()
             if data or filename:
-                return self.field._type(data=data, contentType=contentType, filename=filename)
+                return self.field._type(data=data, filename=filename)
             else:
                 return self.field.missing_value
         

--- a/plone/formwidget/namedfile/widget.txt
+++ b/plone/formwidget/namedfile/widget.txt
@@ -512,8 +512,11 @@ A data string is converted to the appropriate type:
   >>> image_converter.toFieldValue('random data')
   <plone.namedfile.file.NamedImage object at ...>
 
-A FileUpload object is converted to the appropriate type, preserving filename
-and content type, and possibly handling international characters in filenames.
+A FileUpload object is converted to the appropriate type, preserving filename,
+and possibly handling international characters in filenames.
+The content type sent by the browser will be ignored because it's unreliable
+- it's left to the implementation of the file field to determine the proper
+content type.
 
   >>> myfile = cStringIO.StringIO('File upload contents.')
   >>> # \xc3\xb8 is UTF-8 for a small letter o with slash
@@ -524,8 +527,11 @@ and content type, and possibly handling international characters in filenames.
   'File upload contents.'
   >>> file_obj.filename
   u'rand\xf8m.txt'
-  >>> file_obj.contentType
-  'text/x-dummy'
+
+Content type from headers sent by browser should be ignored:
+
+  >>> file_obj.contentType != 'text/x-dummy'
+  True
 
   >>> myfile = cStringIO.StringIO('Random image content.')
   >>> aFieldStorage = FieldStorageStub(myfile, filename='random.png', headers={'Content-Type': 'image/x-dummy'})
@@ -534,8 +540,9 @@ and content type, and possibly handling international characters in filenames.
   'Random image content.'
   >>> image_obj.filename
   u'random.png'
-  >>> image_obj.contentType
-  'image/x-dummy'
+  >>> image_obj.contentType != 'image/x-dummy'
+  True
+
 
 However, a zero-length, unnamed FileUpload results in the field's missing_value
 being returned.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.0.11.dev0'
+version = '1.1.dev0'
 
 setup(name='plone.formwidget.namedfile',
       version=version,


### PR DESCRIPTION
Currently `plone.formwidget.namedfile` [extracts the contentType](https://github.com/plone/plone.formwidget.namedfile/blob/master/plone/formwidget/namedfile/converter.py#L39) 
from the file upload request sent by the browser (a `ZPublisher.HTTPRequest.FileUpload` instance), and passes that contentType to e.g. `NamedBlobFile()`.

This is a problem because the contentTypes sent by browsers are unreliable at best, and plain wrong in the worst case.

We've done some extensive tests with various browsers on different operating systems, and the results couldn't be more random. A particular version of browser X on Mac OS 10.Y can send a totally different content type than the 
same browser on the same minor OS version on a different machine. It also depends on the software that is installed client-side. Certain applications register MIME types for their handled formats in the respective OS registry, causing browsers to send a different content type than they would without that application being installed.

In the end, I believe in the context of a CMS like Plone, the server side should be in control of determining the MIME type of an uploaded file:
- You want it to be consistent. Irrespective of whether it's the _right_ MIME type or not, all the `.docx` NamedFiles on that Plone site should have the same content type.
- Browsers can send MIME type that is completely wrong: Wrong variant, wrong subtype, wrong major type, even malformed type ('application/' for example.)
- Sometimes browsers simply can't know the right MIME type: Unless "exotic application XY" is installed and has registered its types, the browser can't know about them, even if he's just a middleman that's supposed to upload
  a file the user never intended to edit on his machine.

My suggestion would be this:
- Extract extension from the filename
- Look up the extension in the Plone MIME type registry
- If that fails, fall back to the Python MIME type registry available trough the `mimetypes` module
- If that fails, use the magic bytes of the content to guess the MIME type (for example by using python-magic)
- Only if all that failed fall back to the contentType sent by the browser.

If you want to test this behavior yourself, here's a quick & dirty browser view that presents you with the relevant information: https://gist.github.com/lukasgraf/5949331
