### PR TITLE
The context should be ignored, but not the value if explicitly set. 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.0.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The context should be ignored, but not the value if explicitly set.
+  plone.multilingual will set the value for language-independent fields
+  when translating.
+  [regebro]
 
 
 1.0.7 (2013-08-13)

--- a/plone/formwidget/namedfile/widget.py
+++ b/plone/formwidget/namedfile/widget.py
@@ -33,10 +33,9 @@ class NamedFileWidget(Explicit, file.FileWidget):
     
     @property
     def allow_nochange(self):
-        return not self.ignoreContext and \
-                   self.field is not None and \
-                   self.value is not None and \
-                   self.value != self.field.missing_value
+        return self.field is not None and \
+               self.value is not None and \
+               self.value != self.field.missing_value
     
     @property
     def filename(self):
@@ -92,6 +91,8 @@ class NamedFileWidget(Explicit, file.FileWidget):
         if action == 'remove':
             return None
         elif action == 'nochange':
+            if self.value is not None:
+                return self.value
             if self.ignoreContext:
                 return default
             dm = getMultiAdapter((self.context, self.field,), IDataManager)


### PR DESCRIPTION
plone.multilingual will set the value for language-independent fields when translating, and since the translation form is an add form, ignoreContext is set. Unfortunately ignoreContext makes the widget ignore both context and value, which makes it impossible to have a language independent namedfile.

This change fixes that.
