### PR TITLE
Base64Converter for file/image widgets on ASCII fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0.12 (unreleased)
 -------------------
 
+- Add Base64 data converter for NamedImage and NamedFile widgets on ASCII
+  fields with base64 encoded data and filename. Now the NamedImage and
+  NamedFile widgets can be used with ``zope.schema.ASCII`` fields.
+  [thet]
+
 - PEP 8.
   [thet]
 

--- a/plone/formwidget/namedfile/configure.zcml
+++ b/plone/formwidget/namedfile/configure.zcml
@@ -12,6 +12,7 @@
   <i18n:registerTranslations directory="locales" />
 
   <adapter factory=".converter.NamedDataConverter" />
+  <adapter factory=".converter.Base64Converter" />
   <adapter factory=".validator.NamedFileWidgetValidator" />
 
   <class class=".widget.NamedFileWidget">


### PR DESCRIPTION
Add Base64 data converter for NamedImage and NamedFile widgets on ASCII fields
with base64 encoded data and filename. Now the NamedImage and NamedFile widgets
can be used with ``zope.schema.ASCII`` fields.