### PR TITLE
Fix Custom Site-Logo will be deleted on re-edit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fix issue, where NamedFileWidget and NamedImageWidget on ``zope.schema.ASCII`` fields cleared the field values on resubmit with action ``nochange``.
+  Fixes: plone/Products.CMFPlone#1144
+  [thet]
 
 
 1.0.14 (2016-02-12)

--- a/plone/formwidget/namedfile/tests.py
+++ b/plone/formwidget/namedfile/tests.py
@@ -1,16 +1,55 @@
 # -*- coding: utf-8 -*-
-from z3c.form import testing
 import doctest
 import unittest
+# import interlude
+
+
+def setUp(self):
+    """Test setUp based on z3c.form.testing.setUp minus their globals.
+    """
+    from zope.component.testing import setUp
+    setUp()
+    from zope.container.testing import setUp
+    setUp()
+    from zope.component import hooks
+    hooks.setHooks()
+    from zope.traversing.testing import setUp
+    setUp()
+
+    from zope.publisher.browser import BrowserLanguages
+    from zope.publisher.interfaces.http import IHTTPRequest
+    from zope.i18n.interfaces import IUserPreferredLanguages
+    import zope.component
+    zope.component.provideAdapter(
+        BrowserLanguages, [IHTTPRequest], IUserPreferredLanguages)
+
+    from zope.site.folder import rootFolder
+    site = rootFolder()
+    from zope.site.site import LocalSiteManager
+    from zope.component.interfaces import ISite
+    if not ISite.providedBy(site):
+        site.setSiteManager(LocalSiteManager(site))
+    hooks.setSite(site)
+
+
+def tearDown(self):
+    """Test tearDown based on z3c.form.testing.tearDown minus their globals.
+    """
+    from zope.testing import cleanup
+    from zope.component import hooks
+    cleanup.cleanUp()
+    hooks.resetHooks()
+    hooks.setSite()
 
 
 def test_suite():
-    return unittest.TestSuite((
-        doctest.DocFileSuite(
-            'widget.rst',
-            setUp=testing.setUp,
-            tearDown=testing.tearDown,
-            optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,
-            encoding='utf-8'
-        ),
+    suite = unittest.TestSuite()
+    suite.addTest(doctest.DocFileSuite(
+        'widget.rst',
+        setUp=setUp,
+        tearDown=tearDown,
+        optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,
+        encoding='utf-8',
+        # globs={'interact': interlude.interact},
     ))
+    return suite

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,10 @@ setup(
         'z3c.form',
     ],
     extras_require={
-        'test': ['z3c.form [test]'],
+        'test': [
+            'z3c.form [test]',
+            # 'interlude'
+        ],
     },
     entry_points="""
     [z3c.autoinclude.plugin]


### PR DESCRIPTION
Fix issue, where NamedFileWidget and NamedImageWidget on ``zope.schema.ASCII`` fields cleared the field values on resubmit with action ``nochange``.
Fixes: plone/Products.CMFPlone#1144

Introduces horrible doctest :/
z3c.form must die!