### PR TITLE
Fix issue where display widget failed to render fields on fieldsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix issue where display widget failed to render file fields located
+  on form fieldsets, because of broken generated download url
+  [datakurre]
 
 
 2.0.2 (2016-08-15)

--- a/plone/formwidget/namedfile/widget.py
+++ b/plone/formwidget/namedfile/widget.py
@@ -17,6 +17,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from Products.MimetypesRegistry.common import MimeTypeException
 from z3c.form.browser import file
+from z3c.form.group import Group
 from z3c.form.interfaces import IDataManager
 from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import IFormLayer
@@ -147,10 +148,18 @@ class NamedFileWidget(Explicit, file.FileWidget):
 
         absolute_url_method = getattr(self.context, 'absolute_url', None)
         if absolute_url_method:
-            url_parts.extend([
-                absolute_url_method(),
-                getattr(self.form, '__name__', None),
-            ])
+            if isinstance(self.form, Group):
+                url_parts.extend([
+                    absolute_url_method(),
+                    getattr(
+                        getattr(self.form, '__parent__', None),
+                        '__name__', None),
+                ])
+            else:
+                url_parts.extend([
+                    absolute_url_method(),
+                    getattr(self.form, '__name__', None),
+                ])
         else:
             url_parts.append(self.request.getURL())
 

--- a/plone/formwidget/namedfile/widget.rst
+++ b/plone/formwidget/namedfile/widget.rst
@@ -970,6 +970,17 @@ view would get all ``Content`` instances on the folder and then use our widget
   >>> file_widget.download_url
   'http://127.0.0.1/content1/test-form/++widget++file_field/@@download/data.txt'
 
+The download URL also stays the same also when the field belongs to a group of
+a group form. This behavior assumes that groups are used to map fieldsets on a
+form (and not a group of separate objects)::
+
+  >>> from z3c.form.group import Group
+  >>> group = Group(content, file_widget.request, form)
+  >>> group.__name__ = 'test-fieldset'
+  >>> file_widget.form = group
+  >>> file_widget.download_url
+  'http://127.0.0.1/content1/test-form/++widget++file_field/@@download/data.txt'
+
 Some times the context does not have an URL i.e ``context.absolute_url`` is
 not implemented. In these cases the download URL will be::
 


### PR DESCRIPTION
To reproduce:

* Create TTW a new Dexterity type with a named file field on a fieldset.
* Add content with image
* Image does not render, because generated path includes fieldset name (obj/fieldset/++widget++ ...)