### PR TITLE
Fixing potential UnicodeError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixing UnicodeError when the @@z3cform_validate_field view sends
+  a filename with type unicode. (collective.easyform in our case)
 
 
 2.0.3 (2017-07-03)

--- a/plone/formwidget/namedfile/converter.py
+++ b/plone/formwidget/namedfile/converter.py
@@ -45,6 +45,8 @@ class NamedDataConverter(BaseDataConverter):
                 return self.field.missing_value
 
         else:
+            if isinstance(value, unicode):
+                value = value.encode('utf-8')
             return self.field._type(data=str(value))
 
 


### PR DESCRIPTION
Fixing UnicodeError when the @@z3cform_validate_field view sends a filename with type unicode. (collective.easyform in my case)