### PR TITLE
On form validation errors after submitting, keep the already uploaded image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bug fixes:
 
 - Prepare for Python 2 / 3 compatibility
   [ale-rt, pbauer]
+- On form validation errors after submitting, keep the already uploaded image.
+  [thet]
 
 
 2.0.5 (2017-11-26)

--- a/plone/formwidget/namedfile/configure.zcml
+++ b/plone/formwidget/namedfile/configure.zcml
@@ -12,6 +12,7 @@
   <adapter factory=".converter.NamedDataConverter" />
   <adapter factory=".converter.Base64Converter" />
   <adapter factory=".validator.NamedFileWidgetValidator" />
+  <adapter factory=".utils.FileUploadMap" />
 
   <class class=".widget.NamedFileWidget">
     <require

--- a/plone/formwidget/namedfile/configure.zcml
+++ b/plone/formwidget/namedfile/configure.zcml
@@ -12,7 +12,7 @@
   <adapter factory=".converter.NamedDataConverter" />
   <adapter factory=".converter.Base64Converter" />
   <adapter factory=".validator.NamedFileWidgetValidator" />
-  <adapter factory=".utils.FileUploadMap" />
+  <adapter factory=".utils.FileUploadTemporaryStorage" />
 
   <class class=".widget.NamedFileWidget">
     <require

--- a/plone/formwidget/namedfile/converter.py
+++ b/plone/formwidget/namedfile/converter.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from plone.formwidget.namedfile import utils
 from plone.formwidget.namedfile.interfaces import INamedFileWidget
 from plone.formwidget.namedfile.interfaces import INamedImageWidget
 from plone.namedfile.file import NamedFile
@@ -30,7 +31,8 @@ class NamedDataConverter(BaseDataConverter):
 
         if INamed.providedBy(value):
             return value
-        elif isinstance(value, FileUpload):
+
+        elif utils.is_file_upload(value):
 
             filename = safe_basename(value.filename)
 
@@ -107,7 +109,7 @@ class Base64Converter(BaseDataConverter):
             filename = value.filename
             data = value.data
 
-        elif isinstance(value, FileUpload):
+        elif utils.is_file_upload(value):
             filename = safe_basename(value.filename)
             value.seek(0)
             data = value.read()

--- a/plone/formwidget/namedfile/file_input.pt
+++ b/plone/formwidget/namedfile/file_input.pt
@@ -28,6 +28,11 @@
                 doc_type view/file_content_type;
                 icon view/file_icon;
                 filename view/filename;">
+    <input tal:define="up_id view/file_upload_id" tal:condition="up_id" type="hidden" name="${view/name}.file_upload_id" value="${up_id}"/>
+    <span tal:condition="view/is_upload">
+      <tal:i18n i18n:translate="file_already_uploaded">File already uploaded:</tal:i18n>
+      ${view/value/filename}
+    </span>
     <span tal:condition="python: exists and download_url and action=='nochange'">
         <img tal:condition="icon" src="" alt=""
              tal:attributes="src icon;
@@ -52,7 +57,7 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-nochange;
                             onclick string:document.getElementById('${view/id}-input').disabled=true;
-                            checked python:(action == 'nochange') and 'checked' or None;"
+                            checked python:((action == 'nochange') and 'checked') or view.is_upload or None;"
             />
         <label
             tal:attributes="for string:${view/id}-nochange" i18n:translate="file_keep">Keep existing file</label>
@@ -65,7 +70,7 @@
                 tal:attributes="name string:${view/name}.action;
                                 id string:${view/id}-remove;
                                 onclick string:document.getElementById('${view/id}-input').disabled=true;
-                                checked python:action == 'remove' and 'checked' or None;"
+                                checked python:((action == 'remove') and 'checked') or None;"
                 />
             <label
                 tal:attributes="for string:${view/id}-remove" i18n:translate="file_remove">Remove existing file</label>
@@ -78,7 +83,8 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-replace;
                             onclick string:document.getElementById('${view/id}-input').disabled=false;
-                            checked python:action == 'replace' and 'checked' or None;" />
+                            checked python:((action == 'replace') and 'checked' and not view.is_upload) or None;"
+            />
         <label
             tal:attributes="for string:${view/id}-replace" i18n:translate="file_replace">Replace with new file</label>
     </div>

--- a/plone/formwidget/namedfile/file_input.pt
+++ b/plone/formwidget/namedfile/file_input.pt
@@ -28,11 +28,13 @@
                 doc_type view/file_content_type;
                 icon view/file_icon;
                 filename view/filename;">
-    <input tal:define="up_id view/file_upload_id" tal:condition="up_id" type="hidden" name="${view/name}.file_upload_id" value="${up_id}"/>
-    <span tal:condition="view/is_upload">
-      <tal:i18n i18n:translate="file_already_uploaded">File already uploaded:</tal:i18n>
-      ${view/value/filename}
-    </span>
+    <tal:if tal:define="up_id view/file_upload_id" tal:condition="up_id">
+      <input type="hidden" name="${view/name}.file_upload_id" value="${up_id}"/>
+      <span>
+        <tal:i18n i18n:translate="file_already_uploaded">File already uploaded:</tal:i18n>
+        ${view/value/filename}
+      </span>
+    </tal:if>
     <span tal:condition="python: exists and download_url and action=='nochange'">
         <img tal:condition="icon" src="" alt=""
              tal:attributes="src icon;

--- a/plone/formwidget/namedfile/file_input.pt
+++ b/plone/formwidget/namedfile/file_input.pt
@@ -35,13 +35,13 @@
         ${view/value/filename}
       </span>
     </tal:if>
-    <span tal:condition="python: exists and download_url and action=='nochange'">
+    <span tal:condition="python:exists and download_url and action=='nochange'">
         <img tal:condition="icon" src="" alt=""
              tal:attributes="src icon;
                              alt doc_type;
                              title filename;"/>
         <a
-            tal:content="view/filename"
+            tal:content="filename"
             tal:attributes="href download_url"
             >Filename</a>
         <span class="discreet"> &mdash;<tal:doc_type condition="doc_type">
@@ -59,7 +59,7 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-nochange;
                             onclick string:document.getElementById('${view/id}-input').disabled=true;
-                            checked python:((action == 'nochange') and 'checked') or view.is_upload or None;"
+                            checked python:'checked' if action == 'nochange' else None"
             />
         <label
             tal:attributes="for string:${view/id}-nochange" i18n:translate="file_keep">Keep existing file</label>
@@ -72,7 +72,7 @@
                 tal:attributes="name string:${view/name}.action;
                                 id string:${view/id}-remove;
                                 onclick string:document.getElementById('${view/id}-input').disabled=true;
-                                checked python:((action == 'remove') and 'checked') or None;"
+                                checked python:'checked' if action == 'remove' else None"
                 />
             <label
                 tal:attributes="for string:${view/id}-remove" i18n:translate="file_remove">Remove existing file</label>
@@ -85,7 +85,7 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-replace;
                             onclick string:document.getElementById('${view/id}-input').disabled=false;
-                            checked python:((action == 'replace') and 'checked' and not view.is_upload) or None;"
+                            checked python:'checked' if action == 'replace' else None"
             />
         <label
             tal:attributes="for string:${view/id}-replace" i18n:translate="file_replace">Replace with new file</label>

--- a/plone/formwidget/namedfile/image_input.pt
+++ b/plone/formwidget/namedfile/image_input.pt
@@ -28,6 +28,11 @@
                 allow_nochange view/allow_nochange;
                 doc_type view/file_content_type;
                 icon view/file_icon;">
+    <input tal:define="up_id view/file_upload_id" tal:condition="up_id" type="hidden" name="${view/name}.file_upload_id" value="${up_id}"/>
+    <span tal:condition="view/is_upload">
+      <tal:i18n i18n:translate="image_already_uploaded">Image already uploaded:</tal:i18n>
+      ${view/value/filename}
+    </span>
     <span tal:condition="python:exists and download_url and action=='nochange'">
       <a tal:attributes="href download_url">
           <img tal:replace="structure view/thumb_tag"/>
@@ -55,7 +60,7 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-nochange;
                             onclick string:document.getElementById('${view/id}-input').disabled=true;
-                            checked python:(action == 'nochange') and 'checked' or None;"
+                            checked python:((action == 'nochange') and 'checked') or view.is_upload or None;"
             />
         <label
             tal:attributes="for string:${view/id}-nochange" i18n:translate="image_keep">Keep existing image</label>
@@ -68,7 +73,7 @@
                 tal:attributes="name string:${view/name}.action;
                                 id string:${view/id}-remove;
                                 onclick string:document.getElementById('${view/id}-input').disabled=true;
-                                checked python:action== 'remove' and 'checked' or None;"
+                                checked python:((action == 'remove') and 'checked') or None;"
                 />
             <label
                 tal:attributes="for string:${view/id}-remove" i18n:translate="image_remove">Remove existing image</label>
@@ -81,7 +86,8 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-replace;
                             onclick string:document.getElementById('${view/id}-input').disabled=false;
-                            checked python:action == 'replace' and 'checked' or None;" />
+                            checked python:((action == 'replace') and 'checked' and not view.is_upload) or None;"
+            />
         <label
             tal:attributes="for string:${view/id}-replace" i18n:translate="image_replace">Replace with new image</label>
     </div>

--- a/plone/formwidget/namedfile/image_input.pt
+++ b/plone/formwidget/namedfile/image_input.pt
@@ -28,11 +28,13 @@
                 allow_nochange view/allow_nochange;
                 doc_type view/file_content_type;
                 icon view/file_icon;">
-    <input tal:define="up_id view/file_upload_id" tal:condition="up_id" type="hidden" name="${view/name}.file_upload_id" value="${up_id}"/>
-    <span tal:condition="view/is_upload">
-      <tal:i18n i18n:translate="image_already_uploaded">Image already uploaded:</tal:i18n>
-      ${view/value/filename}
-    </span>
+    <tal:if tal:define="up_id view/file_upload_id" tal:condition="up_id">
+      <input type="hidden" name="${view/name}.file_upload_id" value="${up_id}"/>
+      <span>
+        <tal:i18n i18n:translate="image_already_uploaded">Image already uploaded:</tal:i18n>
+        ${view/value/filename}
+      </span>
+    </tal:if>
     <span tal:condition="python:exists and download_url and action=='nochange'">
       <a tal:attributes="href download_url">
           <img tal:replace="structure view/thumb_tag"/>

--- a/plone/formwidget/namedfile/image_input.pt
+++ b/plone/formwidget/namedfile/image_input.pt
@@ -22,12 +22,12 @@
                     accesskey view/accesskey;
                     onselect view/onselect;"
     tal:define="download_url view/download_url;
-                filename view/filename;
                 exists python: view.value is not None;
                 action view/action;
                 allow_nochange view/allow_nochange;
                 doc_type view/file_content_type;
-                icon view/file_icon;">
+                icon view/file_icon;
+                filename view/filename;">
     <tal:if tal:define="up_id view/file_upload_id" tal:condition="up_id">
       <input type="hidden" name="${view/name}.file_upload_id" value="${up_id}"/>
       <span>
@@ -62,7 +62,7 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-nochange;
                             onclick string:document.getElementById('${view/id}-input').disabled=true;
-                            checked python:((action == 'nochange') and 'checked') or view.is_upload or None;"
+                            checked python:'checked' if action == 'nochange' else None"
             />
         <label
             tal:attributes="for string:${view/id}-nochange" i18n:translate="image_keep">Keep existing image</label>
@@ -75,7 +75,7 @@
                 tal:attributes="name string:${view/name}.action;
                                 id string:${view/id}-remove;
                                 onclick string:document.getElementById('${view/id}-input').disabled=true;
-                                checked python:((action == 'remove') and 'checked') or None;"
+                                checked python:'checked' if action == 'remove' else None"
                 />
             <label
                 tal:attributes="for string:${view/id}-remove" i18n:translate="image_remove">Remove existing image</label>
@@ -88,7 +88,7 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-replace;
                             onclick string:document.getElementById('${view/id}-input').disabled=false;
-                            checked python:((action == 'replace') and 'checked' and not view.is_upload) or None;"
+                            checked python:'checked' if action == 'replace' else None"
             />
         <label
             tal:attributes="for string:${view/id}-replace" i18n:translate="image_replace">Replace with new image</label>

--- a/plone/formwidget/namedfile/interfaces.py
+++ b/plone/formwidget/namedfile/interfaces.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from z3c.form.interfaces import IFileWidget
 from zope import schema
+from zope.interface import Attribute
 from zope.interface import Interface
 
 
@@ -30,7 +31,15 @@ class INamedImageWidget(INamedFileWidget):
     alt = schema.TextLine(title=u"Image alternative text", required=False)
 
 
-class IFileUploadMap(Interface):
+class IFileUploadTemporaryStorage(Interface):
     """Temporary storage adapter for file uploads.
     To be used to not need to re-upload files after form submission errors.
     """
+    upload_map = Attribute("""
+        Mapping for temporary uploads.
+        Key is a uuid4.hex value.
+        The default storage is the annotation storage of the poral root.
+    """)
+
+    def cleanup():
+        """Removes stale temporary uploads from the upload storage"""

--- a/plone/formwidget/namedfile/interfaces.py
+++ b/plone/formwidget/namedfile/interfaces.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from z3c.form.interfaces import IFileWidget
 from zope import schema
+from zope.interface import Interface
 
 
 class INamedFileWidget(IFileWidget):
@@ -27,3 +28,9 @@ class INamedImageWidget(INamedFileWidget):
     height = schema.Int(title=u"Image height", min=0, required=False)
     thumb_tag = schema.Text(title=u"Thumbnail image tag", required=False)
     alt = schema.TextLine(title=u"Image alternative text", required=False)
+
+
+class IFileUploadMap(Interface):
+    """Temporary storage adapter for file uploads.
+    To be used to not need to re-upload files after form submission errors.
+    """

--- a/plone/formwidget/namedfile/tests.py
+++ b/plone/formwidget/namedfile/tests.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import doctest
-import unittest
 from plone.formwidget.namedfile.testing import INTEGRATION_TESTING
 from plone.testing import layered
+
+import doctest
+import unittest
 
 
 def test_suite():

--- a/plone/formwidget/namedfile/utils.py
+++ b/plone/formwidget/namedfile/utils.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from BTrees.OOBTree import OOBTree
+from datetime import datetime
+from datetime import timedelta
+from plone.formwidget.namedfile.interfaces import IFileUploadMap
+from random import randint
+from zope.annotation.interfaces import IAnnotations
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+from ZPublisher.HTTPRequest import FileUpload
+
+
+FILE_UPLOAD_MAP_KEY = 'file_upload_map'
+FILE_UPLOAD_EXPIRATION_TIME = 30*60  # seconds
+FALLBACK_DATE = datetime(2000, 2, 2)
+
+
+def is_file_upload(item):
+    """Check if ``item`` is a file upload.
+    """
+    return isinstance(item, FileUpload)
+
+
+@implementer(IFileUploadMap)
+@adapter(Interface)
+class FileUploadMap(object):
+    """Temporary storage adapter for file uploads.
+    To be used to not need to re-upload files after form submission errors.
+    """
+
+    def __init__(self, context):
+        self.context = context
+
+    @property
+    def upload_map(self):
+        annotations = IAnnotations(self.context)
+        # file_upload_id is of type long, therefore we need a OOBTree
+        upload_map = annotations.get(FILE_UPLOAD_MAP_KEY, OOBTree())
+
+        for key, val in upload_map.items():
+            if val.get('dt', FALLBACK_DATE) < (
+                datetime.now() - timedelta(
+                    seconds=FILE_UPLOAD_EXPIRATION_TIME
+                )
+            ) and randint(0, 5) == 0:  # Avoid conflict errors by deleting only every fifth time  # noqa
+                # Delete expired files or files without timestamp
+                del upload_map[key]
+        return upload_map

--- a/plone/formwidget/namedfile/validator.py
+++ b/plone/formwidget/namedfile/validator.py
@@ -18,6 +18,7 @@ class NamedFileWidgetValidator(validator.SimpleFieldValidator):
             raise InvalidState()
         return super(NamedFileWidgetValidator, self).validate(value, force)
 
+
 validator.WidgetValidatorDiscriminators(
     NamedFileWidgetValidator,
     field=INamedField

--- a/plone/formwidget/namedfile/widget.py
+++ b/plone/formwidget/namedfile/widget.py
@@ -1,12 +1,19 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_inner
 from Acquisition import Explicit
+from datetime import datetime
+from plone.formwidget.namedfile import utils
 from plone.formwidget.namedfile.converter import b64decode_file
+from plone.formwidget.namedfile.interfaces import IFileUploadMap
 from plone.formwidget.namedfile.interfaces import INamedFileWidget
 from plone.formwidget.namedfile.interfaces import INamedImageWidget
+from plone.namedfile.file import NamedBlobFile
+from plone.namedfile.file import NamedBlobImage
 from plone.namedfile.file import NamedFile
 from plone.namedfile.file import NamedImage
 from plone.namedfile.interfaces import INamed
+from plone.namedfile.interfaces import INamedBlobFileField
+from plone.namedfile.interfaces import INamedBlobImageField
 from plone.namedfile.interfaces import INamedFileField
 from plone.namedfile.interfaces import INamedImage
 from plone.namedfile.interfaces import INamedImageField
@@ -34,9 +41,10 @@ from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound
 from zope.schema.interfaces import IASCII
 from zope.size import byteDisplay
-from ZPublisher.HTTPRequest import FileUpload
 
 import six
+import uuid
+
 
 try:
     from os import SEEK_END
@@ -48,12 +56,24 @@ def _make_namedfile(value, field, widget):
     """Return a NamedImage or NamedFile instance, if it isn't already one -
     e.g. when it's base64 encoded data.
     """
+    if INamed.providedBy(value):
+        return value
+
     if isinstance(value, six.string_types) and IASCII.providedBy(field):
         filename, data = b64decode_file(value)
-        if INamedImageWidget.providedBy(widget):
-            value = NamedImage(data=data, filename=filename)
-        else:
-            value = NamedFile(data=data, filename=filename)
+    elif isinstance(value, dict):
+        filename = value['filename']
+        data = value['data']
+
+    if INamedBlobImageField.providedBy(field):
+        value = NamedBlobImage(data=data, filename=filename)
+    elif INamedImageField.providedBy(field):
+        value = NamedImage(data=data, filename=filename)
+    elif INamedBlobFileField.providedBy(field):
+        value = NamedBlobFile(data=data, filename=filename)
+    else:
+        value = NamedFile(data=data, filename=filename)
+
     return value
 
 
@@ -64,6 +84,28 @@ class NamedFileWidget(Explicit, file.FileWidget):
 
     klass = u'named-file-widget'
     value = None  # don't default to a string
+
+    @property
+    def is_upload(self):
+        return utils.is_file_upload(self.value)
+
+    @property
+    def file_upload_id(self):
+        """Temporary store the uploaded file contents with a file_upload_id key.
+        In case of form validation errors the already uploaded image can then
+        be reused.
+        """
+        if self.is_upload:
+            self.value.seek(0)
+            upload_id = uuid.uuid4().int  # type long
+            upload_map = IFileUploadMap(getSite()).upload_map
+            upload_map[upload_id] = {
+                'filename': self.value.filename,
+                'data': self.value.read(),
+                'dt': datetime.now(),
+            }
+            return upload_id
+        return None
 
     @property
     def allow_nochange(self):
@@ -77,7 +119,7 @@ class NamedFileWidget(Explicit, file.FileWidget):
             return None
         elif INamed.providedBy(self.value):
             return self.value.filename
-        elif isinstance(self.value, FileUpload):
+        elif utils.is_file_upload(self.value):
             return safe_basename(self.value.filename)
         else:
             return None
@@ -181,9 +223,11 @@ class NamedFileWidget(Explicit, file.FileWidget):
         return action
 
     def extract(self, default=NOVALUE):
+        url = self.request.getURL()
         action = self.request.get("%s.action" % self.name, None)
-        if self.request.get(
-                'PATH_INFO', '').endswith('kss_z3cform_inline_validation'):
+        if url.endswith('kss_z3cform_inline_validation')\
+                or url.endswith('z3cform_validate_field'):
+            # Ignore validation requests.
             action = 'nochange'
 
         if action == 'remove':
@@ -191,6 +235,42 @@ class NamedFileWidget(Explicit, file.FileWidget):
         elif action == 'nochange':
             if self.value is not None:
                 return self.value
+
+            if url.endswith('z3cform_validate_field'):
+                # Ignore validation requests.
+                return None
+
+            # Handle already uploaded files in case of previous form errors
+            file_upload_id = self.request.get(
+                "%s.file_upload_id" % self.name
+            ) or 0
+            try:
+                file_upload_id = int(file_upload_id)
+            except ValueError:
+                file_upload_id = None
+            if file_upload_id:
+                upload_map = IFileUploadMap(getSite()).upload_map
+                fileinfo = upload_map.get(file_upload_id, {})
+                filename = fileinfo.get('filename')
+                data = fileinfo.get('data')
+                if filename or data:
+                    filename = safe_basename(filename)
+                    if (
+                            filename is not None
+                            and not isinstance(filename, unicode)
+                    ):
+                        # work-around for
+                        # https://bugs.launchpad.net/zope2/+bug/499696
+                        filename = filename.decode('utf-8')
+                    del upload_map[file_upload_id]
+                    value = {
+                        'data': data,
+                        'filename': filename,
+                    }
+                    ret = _make_namedfile(value, self.field, self)
+
+                    return ret
+
             if self.ignoreContext:
                 return default
             dm = getMultiAdapter((self.context, self.field,), IDataManager)
@@ -201,7 +281,7 @@ class NamedFileWidget(Explicit, file.FileWidget):
 
         # empty unnamed FileUploads should not count as a value
         value = super(NamedFileWidget, self).extract(default)
-        if isinstance(value, FileUpload):
+        if utils.is_file_upload(value):
             value.seek(0, SEEK_END)
             empty = value.tell() == 0
             value.seek(0)

--- a/plone/formwidget/namedfile/widget.py
+++ b/plone/formwidget/namedfile/widget.py
@@ -87,8 +87,9 @@ class NamedFileWidget(Explicit, file.FileWidget):
     _file_upload_id = None
 
     @property
-    def is_upload(self):
-        return utils.is_file_upload(self.value)
+    def is_uploaded(self):
+        return utils.is_file_upload(self.value)\
+            or INamed.providedBy(self.value)
 
     @property
     def file_upload_id(self):
@@ -102,7 +103,7 @@ class NamedFileWidget(Explicit, file.FileWidget):
             return self._file_upload_id
 
         upload_id = None
-        if self.is_upload or INamed.providedBy(self.value):
+        if self.is_uploaded:
             data = None
             if INamed.providedBy(self.value):
                 # previously uploaded and failed
@@ -229,8 +230,10 @@ class NamedFileWidget(Explicit, file.FileWidget):
 
     def action(self):
         action = self.request.get("%s.action" % self.name, "nochange")
-        if hasattr(self.form, 'successMessage')\
-                and self.form.status == self.form.successMessage:
+        if self.is_uploaded or (
+            hasattr(self.form, 'successMessage')
+            and self.form.status == self.form.successMessage
+        ):
             # if form action completed successfully, we want nochange
             action = 'nochange'
         return action

--- a/plone/formwidget/namedfile/widget.rst
+++ b/plone/formwidget/namedfile/widget.rst
@@ -145,12 +145,22 @@ The rendering is unchanged::
 
   >>> print(file_widget.render())
   <span id="widget.id.file" class="named-file-widget">
+      <input type="hidden" name="widget.name.file.file_upload_id" value="...
+      <span>
+        File already uploaded:
+        foo.bar
+      </span>
       <input type="file" id="widget.id.file-input"
              name="widget.name.file" />
   </span>
 
   >>> print(image_widget.render())
   <span id="widget.id.image" class="named-image-widget">
+      <input type="hidden" name="widget.name.image.file_upload_id" value="...
+      <span>
+        Image already uploaded:
+        foo.bar
+      </span>
       <input type="file" id="widget.id.image-input"
              name="widget.name.image" />
   </span>
@@ -659,7 +669,7 @@ Let's upload data::
   >>> content.file_field
   'filenameb64:ZmlsZTEudHh0;datab64:ZmlsZSAxIGNvbnRlbnQu'
 
-Check that we have a good image that PIL can handle:
+Check that we have a good image that PIL can handle::
 
   >>> import PIL.Image
   >>> PIL.Image.open(get_file('image.jpg'))


### PR DESCRIPTION
This is a improved version of: https://github.com/plone/plone.formwidget.namedfile/pull/31
This PR fixes: https://github.com/collective/collective.easyform/issues/92

I need some advice here - especially: Is the usage of the temp directory OK?
I acquire it from the Zope root. Acquisition is something I normally try to avoid, but that's the best way I came up with.

Also, tests need to be written. I'll do that after I got some feedback.