### PR TITLE
fix: close files on tests

### DIFF
--- a/news/36.bugfix
+++ b/news/36.bugfix
@@ -1,0 +1,2 @@
+Close files, so no resource warnings are shown.
+[gforcada]


### PR DESCRIPTION
This avoids resource warnings while running the tests.

Fixes #36 