### PR TITLE
Only keep already uploaded image when it is a POST request

### DIFF
--- a/news/2628.bugfix
+++ b/news/2628.bugfix
@@ -1,0 +1,4 @@
+Only use the new feature for keeping an already uploaded image when it is a POST request.
+Fixes auto csrf error in `site-controlpanel <https://github.com/plone/Products.CMFPlone/issues/2628>`_
+and `personal-information <https://github.com/plone/Products.CMFPlone/issues/2709>`_ page.
+[maurits]

--- a/plone/formwidget/namedfile/tests.py
+++ b/plone/formwidget/namedfile/tests.py
@@ -11,8 +11,19 @@ import unittest
 class Py23DocChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
         if six.PY2:
-            got = re.sub('zope.publisher.interfaces.NotFound', 'NotFound', got)
-            got = re.sub("u'(.*?)'", "'\\1'", want)
+            got = re.sub('NotFound', 'zope.publisher.interfaces.NotFound', got)
+            got = re.sub('InvalidState', 'plone.formwidget.namedfile.validator.InvalidState', got)
+            got = re.sub('RequiredMissing', 'zope.schema._bootstrapinterfaces.RequiredMissing', got)
+            got = re.sub('IOError: cannot identify image file', 'OSError: cannot identify image file', got)
+            got = re.sub('IO instance', 'IO object', got)
+            got = re.sub("u'(.*?)'", "'\\1'", got)
+            got = re.sub('u"(.*?)"', '"\\1"', got)
+            got = re.sub("b'(.*?)'", "'\\1'", got)
+            got = re.sub('b"(.*?)"', '"\\1"', got)
+            want = re.sub("u'(.*?)'", "'\\1'", want)
+            want = re.sub('u"(.*?)"', '"\\1"', want)
+            want = re.sub("b'(.*?)'", "'\\1'", want)
+            want = re.sub('b"(.*?)"', '"\\1"', want)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 

--- a/plone/formwidget/namedfile/widget.rst
+++ b/plone/formwidget/namedfile/widget.rst
@@ -495,7 +495,7 @@ content type::
   >>> file_obj = file_converter.toFieldValue(FileUpload(aFieldStorage))
   >>> file_obj.data
   b'File upload contents.'
-  >>> print(file_obj.filename.encode('utf8'))
+  >>> file_obj.filename.encode('utf8')
   b'rand\xc3\xb8m.txt'
 
 Content type from headers sent by browser should be ignored::
@@ -731,7 +731,7 @@ Check that we have a good image that PIL can handle::
 
   >>> content.image_field = bytes_image_converter.toFieldValue(uploaded)
   >>> content.image_field
-  b'filenameb64:aW1hZ2UuanBn;datab64:/9j/4AAQSkZJRgABAQEAYABgAAD/...
+  b'filenameb64:aW1hZ2UuanBn;datab64:/9j/4AAQSkZJRgABAQEAYABgAAD/...'
 
 Note that PIL cannot open this bytes image, so we cannot scale it::
 


### PR DESCRIPTION
Fixes auto csrf error in site-controlpanel (https://github.com/plone/Products.CMFPlone/issues/2628) and personal-information (https://github.com/plone/Products.CMFPlone/issues/2709) page.

Those two errors are gone when I revert to plone.formwidget.namedfile 2.0.5, so it is introduced by the new feature from PR #32 like @pbauer [suspected](https://github.com/plone/Products.CMFPlone/issues/2709#issuecomment-460769306).

When I see it correctly, that feature is only useful on POST requests. That is what this PR does.