### PR TITLE
Add check for 'Keep existing file'

### DIFF
--- a/news/41.bugfix
+++ b/news/41.bugfix
@@ -1,0 +1,1 @@
+set widget value to z3c.form.interfaces.NOT_CHANGED when the user selects 'Keep Existing File' in the widget, so z3c.form understands the field has not changed

--- a/plone/formwidget/namedfile/converter.py
+++ b/plone/formwidget/namedfile/converter.py
@@ -8,6 +8,7 @@ from plone.namedfile.interfaces import INamed
 from plone.namedfile.interfaces import INamedField
 from plone.namedfile.utils import safe_basename
 from z3c.form.converter import BaseDataConverter
+from z3c.form.interfaces import NOT_CHANGED
 from zope.component import adapts
 from zope.schema.interfaces import IBytes
 from ZPublisher.HTTPRequest import FileUpload
@@ -25,7 +26,10 @@ class NamedDataConverter(BaseDataConverter):
         return value
 
     def toFieldValue(self, value):
-
+        action = self.widget.request.get("%s.action" % self.widget.name, None)
+        if action == 'nochange':
+            return NOT_CHANGED
+        
         if value is None or value == '':
             return self.field.missing_value
 

--- a/plone/formwidget/namedfile/widget.rst
+++ b/plone/formwidget/namedfile/widget.rst
@@ -451,12 +451,18 @@ instances and the two named file/image widgets::
 
   >>> from zope.component import getMultiAdapter
   >>> from z3c.form.interfaces import IDataConverter
-
+  >>> from z3c.form.interfaces import NOT_CHANGED
+  
   >>> file_converter = getMultiAdapter((IContent['file_field'], file_widget), IDataConverter)
   >>> image_converter = getMultiAdapter((IContent['image_field'], image_widget), IDataConverter)
 
-A value of None or '' results in the field's missing_value being returned::
+An initial upload of a file will never include the action field, 
+so let's remove it from our test requests
 
+  >>> del file_widget.request.form['widget.name.file.action']
+  >>> del image_widget.request.form['widget.name.image.action']
+
+A value of None or '' results in the field's missing_value being returned::
   >>> file_converter.toFieldValue(u'') is IContent['file_field'].missing_value
   True
   >>> file_converter.toFieldValue(None) is IContent['file_field'].missing_value
@@ -526,6 +532,17 @@ being returned::
   >>> field_value is IContent['image_field'].missing_value
   True
 
+If the file has already been uploaded and the user selects 'Keep Existing File' 
+in the widget, the widget will include 'action':'nochange' in the form post, 
+and the converter will always set the value to z3c.form.interfaces.NOT_CHANGED::
+
+  >>> file_widget.request.form['widget.name.file.action'] = 'nochange'
+  >>> file_converter.toFieldValue(u'') is NOT_CHANGED
+  True
+  >>> image_widget.request.form['widget.name.image.action'] = 'nochange'
+  >>> image_converter.toFieldValue(u'') is NOT_CHANGED
+  True
+  
 
 The Base64Converter for Bytes fields
 ------------------------------------


### PR DESCRIPTION
This fixes #41 

I would have preferred to use or implement a method on the widget, like

    if self.widget.action == 'nochage'

But it seems there is already an action() method on the widget doing something else that I'm not quite sure of, and not sure where it's used.

So I went straight through to the request.   It seems to work, but I'm not excited about the converter+request cohesion.

to integration test, we need to NOT see the named field showing up in event descriptions when user selects 'Keep existing file' on the widget.

