### PR TITLE
Use latin-1 decoded filename in tests with FileUpload.

### DIFF
--- a/news/1094.bugfix
+++ b/news/1094.bugfix
@@ -1,0 +1,2 @@
+Test fix: use latin-1 decoded filename in tests with FileUpload.
+[maurits]

--- a/plone/formwidget/namedfile/converter.py
+++ b/plone/formwidget/namedfile/converter.py
@@ -71,7 +71,7 @@ def b64encode_file(filename, data):
 
 def b64decode_file(value):
     if isinstance(value, str):
-        value = value.encode("utf8")
+        value = value.encode("utf-8")
     filename, data = value.split(b";")
 
     filename = filename.split(b":")[1]

--- a/plone/formwidget/namedfile/widget.rst
+++ b/plone/formwidget/namedfile/widget.rst
@@ -496,12 +496,13 @@ content type::
 
   >>> myfile = six.BytesIO(b'File upload contents.')
   >>> # \xc3\xb8 is UTF-8 for a small letter o with slash
-  >>> aFieldStorage = FieldStorageStub(myfile, filename=b'rand\xc3\xb8m.txt'.decode('utf8'),
+  >>> # Still, we must decode it using latin-1 according to HTTP/1.1.
+  >>> aFieldStorage = FieldStorageStub(myfile, filename=b'rand\xc3\xb8m.txt'.decode('latin-1'),
   ...     headers={'Content-Type': 'text/x-dummy'})
   >>> file_obj = file_converter.toFieldValue(FileUpload(aFieldStorage))
   >>> file_obj.data
   b'File upload contents.'
-  >>> file_obj.filename.encode('utf8')
+  >>> file_obj.filename.encode('utf-8')
   b'rand\xc3\xb8m.txt'
 
 Content type from headers sent by browser should be ignored::
@@ -640,7 +641,8 @@ filename too::
 
   >>> myfile = six.BytesIO(b'File upload contents.')
   >>> # \xc3\xb8 is UTF-8 for a small letter o with slash
-  >>> aFieldStorage = FieldStorageStub(myfile, filename=b'rand\xc3\xb8m.txt'.decode('utf8'),
+  >>> # Still, we must decode it using latin-1 according to HTTP/1.1.
+  >>> aFieldStorage = FieldStorageStub(myfile, filename=b'rand\xc3\xb8m.txt'.decode('latin-1'),
   ...     headers={'Content-Type': 'text/x-dummy'})
   >>> bytes_file_converter.toFieldValue(FileUpload(aFieldStorage))
   b'filenameb64:cmFuZMO4bS50eHQ=;datab64:RmlsZSB1cGxvYWQgY29udGVudHMu'


### PR DESCRIPTION
This seems to be what browsers actually use, or how the filename is at this point in the zope publishing machinery. See https://github.com/zopefoundation/Zope/pull/1094#issuecomment-1459047253

This PR fixes tests when run with Zope master, once [my PR](https://github.com/zopefoundation/Zope/pull/1101) is merged.
The tests would fail with current Zope 5.8.

I will checkout these branches in https://github.com/plone/buildout.coredev/pull/844 and run the tests there.