### PR TITLE
Add support for accept attribute on file input.

### DIFF
--- a/news/67.feature
+++ b/news/67.feature
@@ -1,0 +1,12 @@
+Add support for the "accept" attribute on file inputs.
+
+If the widget's field - if there is one - has the "accept" attribute set (the
+`NamedImage` field has `image/*` set by default) then this is rendered as an
+`accept` attribute on the file input.
+
+This would restrict the allowed file types before uploading while still being
+checked on the server side.
+
+Fixes: https://github.com/plone/plone.formwidget.namedfile/issues/66
+Depends on: https://github.com/plone/plone.namedfile/pull/158
+[thet]

--- a/plone/formwidget/namedfile/file_input.pt
+++ b/plone/formwidget/namedfile/file_input.pt
@@ -130,7 +130,8 @@
   <div style="padding-left: 1.5em; padding-top: 0.5em;"
        tal:omit-tag="not:allow_nochange"
   >
-    <input type="file"
+    <input accept="${view/accept}"
+           type="file"
            tal:attributes="
              id string:${view/id}-input;
              name view/name;

--- a/plone/formwidget/namedfile/file_input.pt
+++ b/plone/formwidget/namedfile/file_input.pt
@@ -140,6 +140,14 @@
              maxlength view/maxlength;
            "
     />
+    <div class="form-text"
+         tal:condition="view/accept"
+         i18n:translate="namedfile_accepted_types"
+    >
+      Allowed types:
+      <tal:i18n i18n:name="accepted_types">${view/accept}</tal:i18n>.
+    </div>
+
     <script type="text/javascript"
             tal:condition="python:allow_nochange and action != 'replace'"
             tal:content="string:document.getElementById('${view/id}-input').disabled=true;"

--- a/plone/formwidget/namedfile/image_input.pt
+++ b/plone/formwidget/namedfile/image_input.pt
@@ -145,6 +145,14 @@
              maxlength view/maxlength;
            "
     />
+    <div class="form-text"
+         tal:condition="view/accept"
+         i18n:translate="namedfile_accepted_types"
+    >
+      Allowed types:
+      <tal:i18n i18n:name="accepted_types">${view/accept}</tal:i18n>.
+    </div>
+
     <script type="text/javascript"
             tal:condition="python:allow_nochange and action != 'replace'"
             tal:content="string:document.getElementById('${view/id}-input').disabled=true;"

--- a/plone/formwidget/namedfile/image_input.pt
+++ b/plone/formwidget/namedfile/image_input.pt
@@ -135,7 +135,8 @@
   <div style="padding-left: 1.5em; padding-top: 0.5em;"
        tal:omit-tag="not:allow_nochange"
   >
-    <input type="file"
+    <input accept="${view/accept}"
+           type="file"
            tal:attributes="
              id string:${view/id}-input;
              name view/name;

--- a/plone/formwidget/namedfile/widget.py
+++ b/plone/formwidget/namedfile/widget.py
@@ -83,6 +83,12 @@ class NamedFileWidget(Explicit, FileWidget):
     _file_upload_id = None
 
     @property
+    def accept(self):
+        accept = getattr(self.field, "accept", None)
+        if accept:
+            return ", ".join(accept)
+
+    @property
     def is_uploaded(self):
         return utils.is_file_upload(self.value) or INamed.providedBy(self.value)
 

--- a/plone/formwidget/namedfile/widget.rst
+++ b/plone/formwidget/namedfile/widget.rst
@@ -285,7 +285,9 @@ At first, there is no value, so the behaviour is much like before::
   >>> print(image_widget.render())
   <span id="widget.id.image" class="named-image-widget required namedimage-field" >
       <input accept="image/*" type="file" id="widget.id.image-input" name="widget.name.image" />
+      <div class="form-text" >Allowed types: image/*.</div>
   </span>
+
 
 However, if we now set a value, we will have the option of keeping it,
 or changing it.  The filename can handle unicode and international
@@ -440,12 +442,14 @@ At first, there is no value, so the behaviour is much like before::
   >>> print(file_widget_constrained.render())
   <span id="widget.id.file" class="named-file-widget required namedfile-field" >
       <input accept="audio/mp3, audio/flac, .wav" type="file" id="widget.id.file-input" name="widget.name.file" />
+      <div class="form-text" >Allowed types: audio/mp3, audio/flac, .wav.</div>
   </span>
 
   >>> image_widget_constrained.update()
   >>> print(image_widget_constrained.render())
   <span id="widget.id.image" class="named-image-widget required namedimage-field" >
       <input accept="image/webp, image/png, .jpg" type="file" id="widget.id.image-input" name="widget.name.image" />
+      <div class="form-text" >Allowed types: image/webp, image/png, .jpg.</div>
   </span>
 
 

--- a/plone/formwidget/namedfile/widget.rst
+++ b/plone/formwidget/namedfile/widget.rst
@@ -151,7 +151,7 @@ First use a GET request::
   >>> image_widget.extract()
   <ZPublisher.HTTPRequest.FileUpload ...>
 
-The rendering is unchanged:
+The rendering is unchanged::
 
   >>> print(file_widget.render())
   <span id="widget.id.file" class="named-file-widget" >
@@ -284,7 +284,7 @@ At first, there is no value, so the behaviour is much like before::
   >>> image_widget.update()
   >>> print(image_widget.render())
   <span id="widget.id.image" class="named-image-widget required namedimage-field" >
-      <input type="file" id="widget.id.image-input" name="widget.name.image" />
+      <input accept="image/*" type="file" id="widget.id.image-input" name="widget.name.image" />
   </span>
 
 However, if we now set a value, we will have the option of keeping it,
@@ -386,6 +386,67 @@ stored in the field::
   >>> image_widget.update()
   >>> image_widget.extract() is content.image_field
   True
+
+
+Rendering field widgets with constraints on allowed media types
+-----------------------------------------------------------------
+
+The NamedImage already has a constraint on `image/*` mime types for files and
+this is also rendered for the input element. See above.
+You can also customize the allowed media types with the `accept` attribute,
+like shown here::
+
+  >>> class IContentConstrained(Interface):
+  ...     file_field = field.NamedFile(
+  ...         title=u"File",
+  ...         accept=("audio/mp3", "audio/flac", ".wav")
+  ...     )
+  ...     image_field = field.NamedImage(
+  ...         title=u"Image",
+  ...         accept=("image/webp", "image/png", ".jpg")
+  ...     )
+
+  >>> @implementer(IContentConstrained, IImageScaleTraversable, IAttributeAnnotatable)
+  ... class ContentConstrained(object):
+  ...     def __init__(self, file, image):
+  ...         self.file_field = file
+  ...         self.image_field = image
+  ...         self._p_mtime = DateTime()
+  ...         self.path = '/content_constrained'
+  ...
+  ...     def absolute_url(self):
+  ...         return root_url + self.path
+  ...
+  ...     def Title(self):
+  ...         return 'A content item'
+
+  >>> content_constrained = ContentConstrained(None, None)
+
+  >>> file_widget_constrained = NamedFileFieldWidget(IContentConstrained['file_field'], make_request())
+  >>> image_widget_constrained = NamedImageFieldWidget(IContentConstrained['image_field'], make_request())
+
+  >>> file_widget_constrained.context = content_constrained
+  >>> image_widget_constrained.context = content_constrained
+
+  >>> file_widget_constrained.id = 'widget.id.file'
+  >>> file_widget_constrained.name = 'widget.name.file'
+
+  >>> image_widget_constrained.id = 'widget.id.image'
+  >>> image_widget_constrained.name = 'widget.name.image'
+
+At first, there is no value, so the behaviour is much like before::
+
+  >>> file_widget_constrained.update()
+  >>> print(file_widget_constrained.render())
+  <span id="widget.id.file" class="named-file-widget required namedfile-field" >
+      <input accept="audio/mp3, audio/flac, .wav" type="file" id="widget.id.file-input" name="widget.name.file" />
+  </span>
+
+  >>> image_widget_constrained.update()
+  >>> print(image_widget_constrained.render())
+  <span id="widget.id.image" class="named-image-widget required namedimage-field" >
+      <input accept="image/webp, image/png, .jpg" type="file" id="widget.id.image-input" name="widget.name.image" />
+  </span>
 
 
 Download view

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "BTrees",
         "setuptools",
         "plone.base",
-        "plone.namedfile",
+        "plone.namedfile>=6.3.0",
         "Products.MimetypesRegistry",
         "persistent",
         "plone.registry",


### PR DESCRIPTION
Note: This PR Depeds on https://github.com/plone/plone.namedfile/pull/158


If the widget's field - if there is one - has `allowedContentTypes` set (the `NamedImage` field has `image/*` set by default) the allowed content types are rendered as `accept` attribute on the file input.

This already restricts the allowed file types before uploading while still being checked on the server side too.

Fixes: https://github.com/plone/plone.formwidget.namedfile/issues/66
Depeds on: https://github.com/plone/plone.namedfile/pull/158